### PR TITLE
adding dev-only multi_rosbag capability

### DIFF
--- a/license.proto
+++ b/license.proto
@@ -11,6 +11,7 @@ message license_info {
   enum AllowedFeature{
     CAN = 0;
     VIN_ASSOCIATOR = 1;
+    MULTI_ROSBAG = 2;
   }
   string machine_id = 1;
   string expiration_date = 2;


### PR DESCRIPTION
https://seoulrobotics.atlassian.net/browse/AR-4307

Added new entry to allowed_feature enum that allows dev license to use multiple rosbags + live sensors.